### PR TITLE
Update firebase storage to 2.1.0+1 & update path providor 0.5.0+1

### DIFF
--- a/android/local.properties
+++ b/android/local.properties
@@ -1,3 +1,3 @@
-sdk.dir=/Users/alessiopracchia/Library/Android/sdk
-flutter.sdk=/Users/alessiopracchia/work/flutter
+sdk.dir=/home/botanium/Android/Sdk
+flutter.sdk=/home/botanium/flutter
 flutter.versionName=0.0.2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: firebase_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.1.0+1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,7 +80,14 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.0+1"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
   quiver:
     dependency: transitive
     description:
@@ -99,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.4"
   stack_trace:
     dependency: transitive
     description:
@@ -127,14 +134,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   typed_data:
     dependency: transitive
     description:
@@ -150,5 +157,5 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.0.0 <3.0.0"
+  dart: ">=2.1.0 <3.0.0"
   flutter: ">=0.1.4 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_storage: ^1.0.4
-  path_provider: ^0.5.0
+  firebase_storage: ^2.1.0+1
+  path_provider: ^0.5.0+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The current version of the cache image doesn't work with the newer version of the firebase storage