### PR TITLE
Fixes non unique names for cached images

### DIFF
--- a/lib/resource.dart
+++ b/lib/resource.dart
@@ -38,7 +38,8 @@ class Resource {
   Future<Resource> init() async {
     _temp = await _getTempDir();
     _remote = _parse(uri);
-    _local = _parse(_temp.path + '/' + _remote.path.hashCode.toString());
+    _local = _parse(_temp.path + '/' + _remote.hashCode.toString());
+
     return this;
   }
 

--- a/lib/resource.dart
+++ b/lib/resource.dart
@@ -38,7 +38,7 @@ class Resource {
   Future<Resource> init() async {
     _temp = await _getTempDir();
     _remote = _parse(uri);
-    _local = _parse(_temp.path + _remote.path);
+    _local = _parse(_temp.path + '/' + _remote.path.hashCode.toString());
     return this;
   }
 


### PR DESCRIPTION
If you have two different URI's with the same URI but different query parameters this does not appear to work and treats the uri as the same. 

This Fixes issue #6 